### PR TITLE
fix(bridge): support offline/sandboxed builds via FETCHCONTENT env var overrides

### DIFF
--- a/crates/pmetal-bridge/build.rs
+++ b/crates/pmetal-bridge/build.rs
@@ -267,6 +267,15 @@ fn run_cmake_build() -> PathBuf {
     config.define("CMAKE_C_COMPILER", "/usr/bin/cc");
     config.define("CMAKE_CXX_COMPILER", "/usr/bin/c++");
 
+    // Allow offline/sandbox builds (e.g., MacPorts): forward any
+    // FETCHCONTENT_SOURCE_DIR_* and FETCHCONTENT_FULLY_DISCONNECTED env vars
+    // to cmake so pre-fetched source trees are used instead of git clones.
+    for (key, val) in env::vars() {
+        if key.starts_with("FETCHCONTENT_SOURCE_DIR_") || key == "FETCHCONTENT_FULLY_DISCONNECTED" {
+            config.define(&key, &val);
+        }
+    }
+
     #[cfg(target_os = "macos")]
     {
         let target = resolve_deployment_target();

--- a/crates/pmetal-bridge/build.rs
+++ b/crates/pmetal-bridge/build.rs
@@ -383,7 +383,19 @@ fn build_and_link() {
                     #[cfg(target_os = "macos")]
                     set_dylib_install_name(&prefix.join("lib").join(mlx_dylib_name()));
                 }
-                (dst.join("build/lib"), dst.join("build/_deps/mlx-src"))
+                // When FETCHCONTENT_SOURCE_DIR_MLX is set (e.g., MacPorts sandbox),
+                // CMake uses that path directly and never creates _deps/mlx-src.
+                // Fall back to the env var so the bridge C++ is compiled against
+                // the same headers that libmlx.dylib was built from.
+                let mlx_src = dst.join("build/_deps/mlx-src");
+                let mlx_inc = if mlx_src.exists() {
+                    mlx_src
+                } else if let Ok(dir) = env::var("FETCHCONTENT_SOURCE_DIR_MLX") {
+                    PathBuf::from(dir)
+                } else {
+                    dst.join("build/_deps/mlx-src")
+                };
+                (dst.join("build/lib"), mlx_inc)
             }
         };
 


### PR DESCRIPTION
## Summary

- Forward `FETCHCONTENT_SOURCE_DIR_*` and `FETCHCONTENT_FULLY_DISCONNECTED` env vars from the Rust build script to the cmake `Config`, so pre-fetched source trees are used instead of network git clones in sandboxed environments.
- Fix `mlx_include` path resolution: when `FETCHCONTENT_SOURCE_DIR_MLX` is set, CMake uses that directory directly and never creates `_deps/mlx-src`. The `cc::Build` step was hardcoded to look there, so it silently fell back to any system-installed MLX headers (e.g. from `pip install mlx`), which may have a different ABI. Now falls back to the env var value so the bridge C++ is always compiled against the same headers that `libmlx.dylib` was built from.

## Background

`FETCHCONTENT_SOURCE_DIR_<NAME>` is the standard CMake mechanism for overriding FetchContent fetches with pre-downloaded source trees. It is used by MacPorts, NixOS, Gentoo, Debian, and other distro packagers to build from source in network-sandboxed environments. Without these two fixes, packaging pmetal for any such distro results in either a network fetch failure (sandbox blocks outbound connections) or a subtle linker ABI mismatch (bridge compiled against wrong MLX headers → `ThreadLocalStream` symbols missing from the bundled `libmlx.dylib`).

## Test plan

- [ ] Normal developer build (no env vars set): behaviour unchanged — FetchContent fetches from GitHub as before
- [ ] Offline build with `FETCHCONTENT_FULLY_DISCONNECTED=ON` and `FETCHCONTENT_SOURCE_DIR_MLX=/path/to/mlx-0.31.1`: cmake uses pre-fetched source, bridge C++ compiled against correct headers, links successfully
- [ ] Verify `libpmetal_bridge.a` symbol names match `libmlx.dylib` exports (no `ThreadLocalStream` mismatch against v0.31.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)